### PR TITLE
3.13.0a1 release

### DIFF
--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -9,6 +9,11 @@ runs:
     - name: Install dependencies
       run: conda install gh --channel conda-forge
 
+    - name: Configure git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
+
     - name: Delete the tag (if it exists)
       run: |
         if [ `git rev-parse --verify ${{ inputs.VERSION }} 2>/dev/null` ] ;

--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -3,6 +3,8 @@ inputs:
   VERSION:
     description: "Version to roll back"
     required: true
+env:
+  GITHUB_TOKEN: ${{ github.token }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -19,23 +19,32 @@ runs:
     - name: Delete the tag (if it exists)
       shell: bash
       run: |
-        if [ `git rev-parse --verify ${{ inputs.VERSION }} 2>/dev/null` ] ;
+        if [ `git rev-parse --verify ${{ inputs.VERSION }} 2>/dev/null` ]
         then
-           git push origin --delete ${{ inputs.VERSION }};
+          echo "Deleting ${{ inputs.VERSION }} tag"
+          git push origin --delete ${{ inputs.VERSION }}
+        else
+          echo "${{ inputs.VERSION }} tag not found"
         fi
 
     - name: Delete the autorelease branch (if it exists)
       shell: bash
       run: |
-        if [ `git rev-parse --verify autorelease/${{ inputs.VERSION }} 2>/dev/null` ] ;
+        if [ `git rev-parse --verify autorelease/${{ inputs.VERSION }} 2>/dev/null` ]
         then
-           git push origin --delete autorelease/${{ inputs.VERSION }} ;
+          echo "Deleting autorelease/${{ inputs.VERSION }} branch"
+          git push origin --delete autorelease/${{ inputs.VERSION }}
+        else
+          echo "autorelease/${{ inputs.VERSION }} branch not found"
         fi
 
     - name: Delete the Github release (if it exists)
       shell: bash
       run: |
-        if [ `gh release list | awk -F '\t' -v col=3 '{print $col}' | grep -x -F ${{ inputs.VERSION }}` ] ;
+        if [ `gh release list | awk -F '\t' -v col=3 '{print $col}' | grep -x -F ${{ inputs.VERSION }}` ]
         then
-          gh release delete ${{ inputs.VERSION }} --yes ;
+          echo "Deleting ${{ inputs.VERSION }} GitHub release"
+          gh release delete ${{ inputs.VERSION }} --yes
+        else
+          echo "${{ inputs.VERSION }} GitHub release not found"
         fi

--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -6,8 +6,6 @@ inputs:
   GITHUB_TOKEN:
     description: "GitHub token"
     required: true
-env:
-  GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 runs:
   using: "composite"
   steps:
@@ -20,6 +18,7 @@ runs:
       run: |
         git config user.name "GitHub Actions"
         git config user.email "<>"
+        echo "GITHUB_TOKEN=${{ inputs.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
     - name: Delete the tag (if it exists)
       shell: bash

--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: conda install gh
+      run: conda install gh --channel conda-forge
 
     - name: Delete the tag (if it exists)
       run: |

--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -9,10 +9,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install dependencies
-      shell: bash
-      run: conda install gh --channel conda-forge
-
     - name: Configure git
       shell: bash
       run: |

--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -7,14 +7,17 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
+      shell: bash
       run: conda install gh --channel conda-forge
 
     - name: Configure git
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "<>"
+      shell: bash
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "<>"
 
     - name: Delete the tag (if it exists)
+      shell: bash
       run: |
         if [ `git rev-parse --verify ${{ inputs.VERSION }} 2>/dev/null` ] ;
         then
@@ -22,6 +25,7 @@ runs:
         fi
 
     - name: Delete the autorelease branch (if it exists)
+      shell: bash
       run: |
         if [ `git rev-parse --verify autorelease/${{ inputs.VERSION }} 2>/dev/null` ] ;
         then
@@ -29,6 +33,7 @@ runs:
         fi
 
     - name: Delete the Github release (if it exists)
+      shell: bash
       run: |
         if [ `gh release list | awk -F '\t' -v col=3 '{print $col}' | grep -x -F ${{ inputs.VERSION }}` ] ;
         then

--- a/.github/actions/rollback_release/action.yml
+++ b/.github/actions/rollback_release/action.yml
@@ -3,8 +3,11 @@ inputs:
   VERSION:
     description: "Version to roll back"
     required: true
+  GITHUB_TOKEN:
+    description: "GitHub token"
+    required: true
 env:
-  GITHUB_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -299,7 +299,9 @@ jobs:
           requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} pandoc
 
       - name: Make install
-        run: make install
+        run: |
+          conda uninstall build
+          make install
 
         # Not caching chocolatey packages because the cache may not be reliable
         # https://github.com/chocolatey/choco/issues/2134

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -299,9 +299,7 @@ jobs:
           requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} pandoc
 
       - name: Make install
-        run: |
-          conda uninstall build
-          make install
+        run: make install
 
         # Not caching chocolatey packages because the cache may not be reliable
         # https://github.com/chocolatey/choco/issues/2134

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Tag and push
         run: |
           git tag $VERSION
-          git push origin $VERSION $AUTORELEASE_BRANCH
+          git push origin $VERSION
 
       - name: Create a PR from the autorelease branch into main
         run: |

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -118,8 +118,8 @@ jobs:
             --head $AUTORELEASE_BRANCH \
             --title "$VERSION release" \
             --body-file $PR_MESSAGE_FILE \
-            --reviewer @me \
-            --assignee @me \
+            --reviewer ${{ env.GITHUB_ACTOR }} \
+            --assignee ${{ env.GITHUB_ACTOR }} \
             --label auto
 
       - name: Roll back on failure

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -15,6 +15,7 @@ env:
 
 permissions:
   contents: write  # allow this workflow to push changes to the repo
+  pull-requests: write
 
 jobs:
   finalize-and-tag:

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -14,11 +14,7 @@ env:
   # this is necessary for the pr checks
   GITHUB_TOKEN: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
-permissions:
-  contents: write
-  pull-requests: write
-  actions: write
-  checks: write
+permissions: write-all
 
 jobs:
   finalize-and-tag:

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -14,6 +14,12 @@ env:
   # this is necessary for the pr checks
   GITHUB_TOKEN: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  checks: write
+
 jobs:
   finalize-and-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -7,9 +7,6 @@ on:
         required: true
         type: string
 
-defaults:
-  runs-on: ubuntu-latest
-
 env:
   VERSION: ${{ inputs.version }}
   AUTORELEASE_BRANCH: autorelease/${{ inputs.version }}
@@ -17,6 +14,7 @@ env:
 
 jobs:
   finalize-and-tag:
+    runs-on: ubuntu-latest
     steps:
       - name: install dependencies
         run: conda install gh

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "<>"
+          git remote -v
 
       # Members of the natcap software team can push to the autorelease branch on
       # natcap/invest; this branch is a special case for our release process.
@@ -58,7 +59,7 @@ jobs:
       - name: tag and push
         run: |
           git tag $VERSION
-          git push $VERSION $AUTORELEASE_BRANCH
+          git push origin $VERSION $AUTORELEASE_BRANCH
 
       - name: create PR message
         run: |

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -116,9 +116,9 @@ jobs:
             --head $AUTORELEASE_BRANCH \
             --title "$VERSION release" \
             --body-file $PR_MESSAGE_FILE \
-            --reviewer "@me" \
-            --assign "@me" \
-            --labels "auto"
+            --reviewer @me \
+            --assignee @me \
+            --label auto
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Tag and push
         run: |
+          git push origin $AUTORELEASE_BRANCH
           git tag $VERSION
           git push origin $VERSION
 
@@ -86,13 +87,13 @@ jobs:
             any release steps that have completed so far.
 
             ## Review this PR
-            - [] Make sure that the automated changes look correct
-            - [] Wait for BOTH the PR checks AND the [$VERSION tag checks]()
-                 to complete. The $VERSION tag workflow is most important
-                 because it produces the artifacts that will be used in the
-                 next steps of the release process. If it fails for any reason,
+            - [ ] Make sure that the automated changes look correct
+            - [ ] Wait for BOTH the PR checks AND the [$VERSION tag checks]() \
+                 to complete. The $VERSION tag workflow is most important \
+                 because it produces the artifacts that will be used in the \
+                 next steps of the release process. If it fails for any reason, \
                  decline this PR and start over.
-            - [] Download and try out the artifacts from the [tag build]
+            - [ ] Download and try out the artifacts from the [tag build]
 
             **If everything looks good**, approve and merge this PR. This will
             trigger a Github Action that will publish the release. Then go
@@ -110,9 +111,9 @@ jobs:
             due to an intermittent problem**, continue with the release.
             Approve and merge this PR with a comment explaining what happened."
 
-      # - name: Roll back on failure
-      #   if: failure()
-      #   uses: ./.github/actions/rollback_release
-      #   with:
-      #     VERSION: ${{ env.VERSION }}
-      #     GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+      - name: Roll back on failure
+        if: failure()
+        uses: ./.github/actions/rollback_release
+        with:
+          VERSION: ${{ env.VERSION }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: install dependencies
+      - name: Install dependencies
         run: conda install gh --channel conda-forge
 
       - name: Configure git
@@ -32,7 +32,7 @@ jobs:
 
       # Members of the natcap software team can push to the autorelease branch on
       # natcap/invest; this branch is a special case for our release process.
-      - name: create autorelease branch
+      - name: Create autorelease branch
         run: git checkout -b "$AUTORELEASE_BRANCH"
 
       # Replace
@@ -48,7 +48,7 @@ jobs:
       #
       # X.X.X (XXXX-XX-XX)
       # ------------------
-      - name: update HISTORY.rst
+      - name: Update HISTORY.rst
         run: |
           HEADER="$VERSION ($(date '+%Y-%m-%d'))"
           HEADER_LENGTH=${#HEADER}
@@ -59,12 +59,12 @@ jobs:
           git add HISTORY.rst
           git commit -m "Committing the $VERSION release."
 
-      - name: tag and push
+      - name: Tag and push
         run: |
           git tag $VERSION
           git push origin $VERSION $AUTORELEASE_BRANCH
 
-      - name: create PR message
+      - name: Create PR message
         run: |
           echo "
             Release $VERSION and merge into \`main\`
@@ -109,7 +109,7 @@ jobs:
                anything else that needs to be taken care of.
           " > $PR_MESSAGE_FILE
 
-      - name: create a PR from the autorelease branch into main
+      - name: Create a PR from the autorelease branch into main
         run: |
           gh pr create \
             --base main \
@@ -125,3 +125,4 @@ jobs:
         uses: ./.github/actions/rollback_release
         with:
           VERSION: ${{ env.VERSION }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -118,8 +118,8 @@ jobs:
             --head $AUTORELEASE_BRANCH \
             --title "$VERSION release" \
             --body-file $PR_MESSAGE_FILE \
-            --reviewer ${{ env.GITHUB_ACTOR }} \
-            --assignee ${{ env.GITHUB_ACTOR }} \
+            --reviewer $GITHUB_ACTOR \
+            --assignee $GITHUB_ACTOR \
             --label auto
 
       - name: Roll back on failure

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -65,10 +65,16 @@ jobs:
           git tag $VERSION
           git push origin $VERSION $AUTORELEASE_BRANCH
 
-      - name: Create PR message
+      - name: Create a PR from the autorelease branch into main
         run: |
-          echo "
-            PR_MESSAGE=Release $VERSION and merge into \`main\`
+          gh --repo emlys/invest-mirror pr create \
+            --base main \
+            --head task/1160 \
+            --title "$VERSION release" \
+            --reviewer $GITHUB_ACTOR \
+            --assignee $GITHUB_ACTOR \
+            --body "
+            Release $VERSION and merge into \`main\`
 
             # Release $VERSION
 
@@ -107,18 +113,7 @@ jobs:
                that will complete the release.
             2. Take a look at the Release Checklist
                (https://github.com/natcap/invest/wiki/Release-Checklist) and take care of
-               anything else that needs to be taken care of.
-          " >> $GITHUB_ENV
-
-      - name: Create a PR from the autorelease branch into main
-        run: |
-          gh pr create \
-            --base main \
-            --head $AUTORELEASE_BRANCH \
-            --title "$VERSION release" \
-            --body $PR_MESSAGE \
-            --reviewer $GITHUB_ACTOR \
-            --assignee $GITHUB_ACTOR
+               anything else that needs to be taken care of."
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -77,44 +77,38 @@ jobs:
             --body "
             Release $VERSION and merge into \`main\`
 
-            # Release $VERSION
+            # $VERSION Release
 
-            This PR includes automated changes made for the $VERSION release.
+            This PR contains automated changes made for the $VERSION release.
 
-            In addition to the actions workflow triggered by this PR,
-            workflows will also be triggered for the $AUTORELEASE_BRANCH branch
-            and the $VERSION tag.
+            Approving this PR will trigger an action that publishes the
+            release. Declining this PR will trigger an action that rolls back
+            any release steps that have completed so far.
 
-            The $VERSION tag workflow is most important because it produces the
-            artifacts that will be used in the next steps of the release process.
-            If it fails for any reason, decline this PR and start over.
-            Declining this PR will trigger a Github Action that will roll back any
-            release steps that have completed so far.
+            ## Review this PR
+            - [] Make sure that the automated changes look correct
+            - [] Wait for BOTH the PR checks AND the [$VERSION tag checks]()
+                 to complete. The $VERSION tag workflow is most important
+                 because it produces the artifacts that will be used in the
+                 next steps of the release process. If it fails for any reason,
+                 decline this PR and start over.
+            - [] Download and try out the artifacts from the [tag build]
 
-            ## Intermittent failures
-            If the $VERSION tag workflow fails due to an intermittent problem,
-            decline this PR and start over. Declining this PR will trigger a
-            Github Action that will roll back any release steps that have completed
-            so far.
+            **If everything looks good**, approve and merge this PR. This will
+            trigger a Github Action that will publish the release. Then go
+            back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)
+            and complete any remaining tasks.
 
-            If $VERSION tag workflow succeeds, but this PR workflow and/or the
-            $AUTORELEASE_BRANCH branch workflow fail due to an intermittent problem,
-            continue with the release. Approve and merge this PR with a comment
-            explaining what happened.
+            **If there is a bug**, decline this PR. Submit a fix in a separate
+            PR into \`main\`. Once the fix has been merged, restart the release
+            process from the beginning.
 
-            ## Bugs
-            If the workflows reveal a bug in the tagged version, decline this PR.
-            Declining this PR will trigger a Github Action that will roll back any
-            release steps that have completed so far. Submit a fix in a separate PR
-            into \`main\`. Once the fix has been merged, restart the release process
-            from the beginning.
+            **If the $VERSION tag workflow fails due to an intermittent problem**,
+            decline this PR and start over.
 
-            ## If everything looks OK
-            1. Approve and merge this PR. This will trigger a Github Action
-               that will complete the release.
-            2. Take a look at the Release Checklist
-               (https://github.com/natcap/invest/wiki/Release-Checklist) and take care of
-               anything else that needs to be taken care of."
+            **If $VERSION tag workflow succeeds, but this PR workflow fails
+            due to an intermittent problem**, continue with the release.
+            Approve and merge this PR with a comment explaining what happened.
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -21,6 +21,11 @@ jobs:
       - name: install dependencies
         run: conda install gh --channel conda-forge
 
+      - name: Configure git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
+
       # Members of the natcap software team can push to the autorelease branch on
       # natcap/invest; this branch is a special case for our release process.
       - name: create autorelease branch

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -119,8 +119,7 @@ jobs:
             --title "$VERSION release" \
             --body-file $PR_MESSAGE_FILE \
             --reviewer $GITHUB_ACTOR \
-            --assignee $GITHUB_ACTOR \
-            --label auto
+            --assignee $GITHUB_ACTOR
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -16,6 +16,8 @@ jobs:
   finalize-and-tag:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: install dependencies
         run: conda install gh
 

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Create a PR from the autorelease branch into main
         run: |
-          gh --repo emlys/invest-mirror pr create \
+          gh pr create \
             --base main \
             --head $AUTORELEASE_BRANCH \
             --title "$VERSION release" \
@@ -108,7 +108,7 @@ jobs:
 
             **If $VERSION tag workflow succeeds, but this PR workflow fails
             due to an intermittent problem**, continue with the release.
-            Approve and merge this PR with a comment explaining what happened.
+            Approve and merge this PR with a comment explaining what happened."
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           gh --repo emlys/invest-mirror pr create \
             --base main \
-            --head task/1160 \
+            --head $AUTORELEASE_BRANCH \
             --title "$VERSION release" \
             --reviewer $GITHUB_ACTOR \
             --assignee $GITHUB_ACTOR \

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -15,6 +15,7 @@ env:
 permissions:
   contents: write  # allow this workflow to push changes to the repo
   pull-requests: write
+  checks: write
 
 jobs:
   finalize-and-tag:

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -11,6 +11,7 @@ env:
   VERSION: ${{ inputs.version }}
   AUTORELEASE_BRANCH: autorelease/${{ inputs.version }}
   PR_MESSAGE_FILE: pr_message.md
+  GITHUB_TOKEN: ${{ github.token }}
 
 permissions:
   contents: write  # allow this workflow to push changes to the repo
@@ -26,8 +27,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email "<>"
+          # git config user.name "GitHub Actions"
+          # git config user.email "<>"
           git remote -v
 
       # Members of the natcap software team can push to the autorelease branch on

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -12,6 +12,9 @@ env:
   AUTORELEASE_BRANCH: autorelease/${{ inputs.version }}
   PR_MESSAGE_FILE: pr_message.md
 
+permissions:
+  contents: write  # allow this workflow to push changes to the repo
+
 jobs:
   finalize-and-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Configure git
         run: |
-          # git config user.name "GitHub Actions"
-          # git config user.email "<>"
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
           git remote -v
 
       # Members of the natcap software team can push to the autorelease branch on

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -10,21 +10,15 @@ on:
 env:
   VERSION: ${{ inputs.version }}
   AUTORELEASE_BRANCH: autorelease/${{ inputs.version }}
-  GITHUB_TOKEN: ${{ github.token }}
-
-permissions:
-  contents: write  # allow this workflow to push changes to the repo
-  pull-requests: write
-  checks: write
+  # use a personal access token here which has permissions to trigger further actions
+  # this is necessary for the pr checks
+  GITHUB_TOKEN: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
 jobs:
   finalize-and-tag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install dependencies
-        run: conda install gh --channel conda-forge
 
       - name: Configure git
         run: |
@@ -121,4 +115,4 @@ jobs:
         uses: ./.github/actions/rollback_release
         with:
           VERSION: ${{ env.VERSION }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -10,7 +10,6 @@ on:
 env:
   VERSION: ${{ inputs.version }}
   AUTORELEASE_BRANCH: autorelease/${{ inputs.version }}
-  PR_MESSAGE_FILE: pr_message.md
   GITHUB_TOKEN: ${{ github.token }}
 
 permissions:
@@ -69,7 +68,7 @@ jobs:
       - name: Create PR message
         run: |
           echo "
-            Release $VERSION and merge into \`main\`
+            PR_MESSAGE=Release $VERSION and merge into \`main\`
 
             # Release $VERSION
 
@@ -109,17 +108,15 @@ jobs:
             2. Take a look at the Release Checklist
                (https://github.com/natcap/invest/wiki/Release-Checklist) and take care of
                anything else that needs to be taken care of.
-          " > $PR_MESSAGE_FILE
+          " >> $GITHUB_ENV
 
       - name: Create a PR from the autorelease branch into main
         run: |
-          git status
-          git diff
           gh pr create \
             --base main \
             --head $AUTORELEASE_BRANCH \
             --title "$VERSION release" \
-            --body-file $PR_MESSAGE_FILE \
+            --body $PR_MESSAGE \
             --reviewer $GITHUB_ACTOR \
             --assignee $GITHUB_ACTOR
 

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -113,6 +113,8 @@ jobs:
 
       - name: Create a PR from the autorelease branch into main
         run: |
+          git status
+          git diff
           gh pr create \
             --base main \
             --head $AUTORELEASE_BRANCH \

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: install dependencies
-        run: conda install gh
+        run: conda install gh --channel conda-forge
 
       # Members of the natcap software team can push to the autorelease branch on
       # natcap/invest; this branch is a special case for our release process.

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -67,7 +67,7 @@ jobs:
       - name: create PR message
         run: |
           echo "
-            Release $VERSION and merge into main
+            Release $VERSION and merge into \`main\`
 
             # Release $VERSION
 
@@ -98,7 +98,7 @@ jobs:
             If the workflows reveal a bug in the tagged version, decline this PR.
             Declining this PR will trigger a Github Action that will roll back any
             release steps that have completed so far. Submit a fix in a separate PR
-            into `main`. Once the fix has been merged, restart the release process
+            into \`main\`. Once the fix has been merged, restart the release process
             from the beginning.
 
             ## If everything looks OK

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -1,30 +1,23 @@
 name: Release (Part 1 of 2)
 
-on: workflow_dispatch
-
-#!/usr/bin/env bash
-# Initiate a release on the current commit.
-# - Create autorelease branch
-# - Update HISTORY.rst
-# - Commit the changes to HISTORY.rst
-# - Tag the commit
-# - Push the tag
-# - Build workflows run on push, wait for them to finish
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
 
 defaults:
   runs-on: ubuntu-latest
 
 env:
-  VERSION: $1
-  GITHUB_REPO: "natcap/invest"
-  AUTORELEASE_BRANCH: autorelease/$VERSION
+  VERSION: ${{ inputs.version }}
+  AUTORELEASE_BRANCH: autorelease/${{ inputs.version }}
   PR_MESSAGE_FILE: pr_message.md
 
 jobs:
-
   finalize-and-tag:
     steps:
-
       - name: install dependencies
         run: conda install gh
 
@@ -59,8 +52,8 @@ jobs:
 
       - name: tag and push
         run: |
-          git tag "$VERSION"
-          git push https://github.com/${GITHUB_REPO}.git $VERSION $AUTORELEASE_BRANCH
+          git tag $VERSION
+          git push $VERSION $AUTORELEASE_BRANCH
 
       - name: create PR message
         run: |
@@ -110,8 +103,8 @@ jobs:
       - name: create a PR from the autorelease branch into main
         run: |
           gh pr create \
-            --base "$GITHUB_REPO:main" \
-            --head "$GITHUB_REPO:autorelease/$VERSION" \
+            --base main \
+            --head $AUTORELEASE_BRANCH \
             --title "$VERSION release" \
             --body-file $PR_MESSAGE_FILE \
             --reviewer "@me" \

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -110,9 +110,9 @@ jobs:
             due to an intermittent problem**, continue with the release.
             Approve and merge this PR with a comment explaining what happened."
 
-      - name: Roll back on failure
-        if: failure()
-        uses: ./.github/actions/rollback_release
-        with:
-          VERSION: ${{ env.VERSION }}
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+      # - name: Roll back on failure
+      #   if: failure()
+      #   uses: ./.github/actions/rollback_release
+      #   with:
+      #     VERSION: ${{ env.VERSION }}
+      #     GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -1,3 +1,5 @@
+name: Release (Part 2 of 2)
+
 on:
   # this workflow will run any time any PR into main is closed
   pull_request:
@@ -13,7 +15,6 @@ env:
   BRANCH: ${{ github.head_ref }}
 
 jobs:
-
   roll_back_release:
     # run this job if a PR from an autorelease branch into main was closed without merging
     if: startsWith(github.head_ref, 'autorelease') && github.event.pull_request.merged == false
@@ -88,6 +89,3 @@ jobs:
         uses: ./.github/actions/rollback_release
         with:
           VERSION: ${{ env.VERSION }}
-
-
-

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: conda install gh twine
+        run: conda install --channel conda-forge gh twine
 
       - name: Extract version from autorelease branch name
         run: echo "VERSION=${BRANCH:12}" >> $GITHUB_ENV

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -23,6 +23,7 @@ jobs:
         uses: ./.github/actions/rollback_release
         with:
           VERSION: ${{ env.VERSION }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   publish_release:
     # run this job if a PR was merged from an autorelease branch into main
@@ -91,3 +92,4 @@ jobs:
         uses: ./.github/actions/rollback_release
         with:
           VERSION: ${{ env.VERSION }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-defaults:
-  runs-on: ubuntu-latest
-
 env:
   BRANCH: ${{ github.head_ref }}
 
@@ -18,6 +15,7 @@ jobs:
   roll_back_release:
     # run this job if a PR from an autorelease branch into main was closed without merging
     if: startsWith(github.head_ref, 'autorelease') && github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
     steps:
       - name: Roll back on failure
         uses: ./.github/actions/rollback_release
@@ -27,8 +25,8 @@ jobs:
   publish_release:
     # run this job if a PR was merged from an autorelease branch into main
     if: startsWith(github.head_ref, 'autorelease') && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
     steps:
-
       - name: Install dependencies
         run: conda install gh twine
 

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -17,6 +17,8 @@ jobs:
     if: startsWith(github.head_ref, 'autorelease') && github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Roll back on failure
         uses: ./.github/actions/rollback_release
         with:
@@ -27,6 +29,8 @@ jobs:
     if: startsWith(github.head_ref, 'autorelease') && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Install dependencies
         run: conda install gh twine
 

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: conda install --channel conda-forge gh twine
+        run: conda install --channel conda-forge twine
 
       - name: Extract version from autorelease branch name
         run: echo "VERSION=${BRANCH:12}" >> $GITHUB_ENV

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,11 +42,12 @@ Unreleased Changes
     * Fixed a bug in HRA where the model would error when all exposure and
       consequence criteria were skipped for a single habitat. The model now
       correctly handles this case. https://github.com/natcap/invest/issues/1250
+    * Tables in the .xls format are no longer supported. This format was
+      deprecated by ``pandas``. (`#1271 <https://github.com/natcap/invest/issues/1271>`_)
 * Scenic Quality
     * The Scenic Quality model will now raise an error when it encounters a
       geometry that is not a simple Point.  This is in line with the user's
       guide chapter.  https://github.com/natcap/invest/issues/1245
-
 
 3.13.0 (2023-03-17)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,8 +35,12 @@
 
 .. :changelog:
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.13.0a1 (2023-04-06)
+---------------------
 
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,4 +22,4 @@ setuptools_scm>=6.4.0
 requests
 coverage
 xlwt
-build
+build  # pip-only

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -1834,10 +1834,10 @@ def _mask_binary_presence_absence_rasters(
 
 def _open_table_as_dataframe(table_path, **kwargs):
     extension = os.path.splitext(table_path)[1].lower()
-    # Technically, pandas.read_excel can handle xls, xlsx, xlsm, xlsb, odf, ods
-    # and odt file extensions, but I have not tested anything other than XLS
-    # and XLSX, so leaving this as-is from the prior HRA implementation.
-    if extension in {'.xls', '.xlsx'}:
+    # Technically, pandas.read_excel can handle xlsx, xlsm, xlsb, odf, ods
+    # and odt file extensions, but I have not tested anything other than
+    # XLSX, so leaving this as-is from the prior HRA implementation.
+    if extension == '.xlsx':
         excel_df = pandas.read_excel(table_path, **kwargs)
         excel_df.columns = excel_df.columns.str.lower()
         excel_df['path'] = excel_df['path'].apply(
@@ -1906,7 +1906,7 @@ def _parse_criteria_table(criteria_table_path, target_composite_csv_path):
     included in this table.
 
     Args:
-        criteria_table_path (string): The path to a CSV, XLS or XLSX file on
+        criteria_table_path (string): The path to a CSV or XLSX file on
             disk.
         target_composite_csv_path (string): The path to where a new CSV should
             be written containing similar information but in a more easily
@@ -1921,7 +1921,7 @@ def _parse_criteria_table(criteria_table_path, target_composite_csv_path):
     # This function requires that the table is read as a numpy array, so it's
     # easiest to read the table directly.
     extension = os.path.splitext(criteria_table_path)[1].lower()
-    if extension in {'.xls', '.xlsx'}:
+    if extension == '.xlsx':
         df = pandas.read_excel(criteria_table_path, header=None)
     else:
         df = pandas.read_csv(criteria_table_path, header=None, sep=None,
@@ -2476,7 +2476,7 @@ def _override_datastack_archive_criteria_table_path(
     """
     args_key = 'criteria_table_path'
     extension = os.path.splitext(criteria_table_path)[1].lower()
-    if extension in {'.xls', '.xlsx'}:
+    if extension == '.xlsx':
         df = pandas.read_excel(criteria_table_path, header=None)
     else:
         df = pandas.read_csv(criteria_table_path, header=None, sep=None,

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -758,7 +758,6 @@ class HRAUnitTests(unittest.TestCase):
         expected_df['path'] = [os.path.join(self.workspace_dir, 'foo.tif')]
 
         for filename, func in [('target.csv', source_df.to_csv),
-                               ('target.xls', source_df.to_excel),
                                ('target.xlsx', source_df.to_excel)]:
             full_filepath = os.path.join(self.workspace_dir, filename)
             func(full_filepath, index=False)


### PR DESCRIPTION

  Release 3.13.0a1 and merge into `main`

  # 3.13.0a1 Release

  This PR contains automated changes made for the 3.13.0a1 release.

  Approving this PR will trigger an action that publishes the
  release. Declining this PR will trigger an action that rolls back
  any release steps that have completed so far.

  ## Review this PR
  - [ ] Make sure that the automated changes look correct
  - [ ] Wait for BOTH the PR checks AND the [3.13.0a1 tag checks]()        to complete. The 3.13.0a1 tag workflow is most important        because it produces the artifacts that will be used in the        next steps of the release process. If it fails for any reason,        decline this PR and start over.
  - [ ] Download and try out the artifacts from the [tag build]

  **If everything looks good**, approve and merge this PR. This will
  trigger a Github Action that will publish the release. Then go
  back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)
  and complete any remaining tasks.

  **If there is a bug**, decline this PR. Submit a fix in a separate
  PR into `main`. Once the fix has been merged, restart the release
  process from the beginning.

  **If the 3.13.0a1 tag workflow fails due to an intermittent problem**,
  decline this PR and start over.

  **If 3.13.0a1 tag workflow succeeds, but this PR workflow fails
  due to an intermittent problem**, continue with the release.
  Approve and merge this PR with a comment explaining what happened.