### PR TITLE
3.13.0a2 release

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -51,16 +51,24 @@ jobs:
       - name: Download release artifacts
         run: |
           mkdir artifacts
-          gh run download $RUN_ID \
-            --dir artifacts \
-            --name InVEST-Windows-binary.zip \
-            --name InVEST-macOS-binary.zip \
-            --name Workbench-Windows-binary.zip \
-            --name Workbench-macOS-binary.zip \
-            --name InVEST-sample-data.zip \
-            --name InVEST-user-guide.zip \
-            --name "Source distribution.zip" \
-            --name "Wheel for *.zip"
+          # this will download a folder containing each artifact
+          gh --repo emlys/invest-mirror run download $RUN_ID --dir artifacts --pattern "Wheel for *"
+          # move the artifacts out of the folders
+          mv artifacts/*/* artifacts
+          rm -rf artifacts/Wheel*
+          # verify that all 6 wheels are there
+          if [ `find artifacts/* | wc -l` -ne 6 ]; then exit 1; fi
+
+          # download each artifact separately so that the command will fail if
+          # any artifact is not found
+          for artifact in Workbench-Windows-binary \
+                          Workbench-macOS-binary \
+                          InVEST-sample-data \
+                          InVEST-user-guide \
+                          "Source distribution"
+          do
+            gh --repo emlys/invest-mirror run download $RUN_ID --dir artifacts --name "$artifact"
+          done
 
       - name: Create release message
         run: |

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   BRANCH: ${{ github.head_ref }}
+  GITHUB_TOKEN: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
 jobs:
   roll_back_release:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,8 +35,12 @@
 
 .. :changelog:
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.13.0a2 (2023-04-07)
+---------------------
 
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and


### PR DESCRIPTION

  Release 3.13.0a2 and merge into `main`

  # 3.13.0a2 Release

  This PR contains automated changes made for the 3.13.0a2 release.

  Approving this PR will trigger an action that publishes the
  release. Declining this PR will trigger an action that rolls back
  any release steps that have completed so far.

  ## Review this PR
  - [ ] Make sure that the automated changes look correct
  - [ ] Wait for BOTH the PR checks AND the [3.13.0a2 tag checks]()        to complete. The 3.13.0a2 tag workflow is most important        because it produces the artifacts that will be used in the        next steps of the release process. If it fails for any reason,        decline this PR and start over.
  - [ ] Download and try out the artifacts from the [tag build]

  **If everything looks good**, approve and merge this PR. This will
  trigger a Github Action that will publish the release. Then go
  back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)
  and complete any remaining tasks.

  **If there is a bug**, decline this PR. Submit a fix in a separate
  PR into `main`. Once the fix has been merged, restart the release
  process from the beginning.

  **If the 3.13.0a2 tag workflow fails due to an intermittent problem**,
  decline this PR and start over.

  **If 3.13.0a2 tag workflow succeeds, but this PR workflow fails
  due to an intermittent problem**, continue with the release.
  Approve and merge this PR with a comment explaining what happened.