### PR TITLE
3.13.0a4 release

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -9,7 +9,6 @@ on:
       - main
 
 env:
-  BRANCH: ${{ github.head_ref }}
   GITHUB_TOKEN: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
 jobs:
@@ -37,7 +36,7 @@ jobs:
         run: conda install --channel conda-forge twine
 
       - name: Extract version from autorelease branch name
-        run: echo "VERSION=${BRANCH:12}" >> $GITHUB_ENV
+        run: echo "VERSION=$(echo ${{ github.head_ref }} | cut -c 13-)" >> $GITHUB_ENV
 
       - name: Find actions run for the $VERSION tag
         run: |
@@ -70,26 +69,17 @@ jobs:
             gh --repo emlys/invest-mirror run download $RUN_ID --dir artifacts --name "$artifact"
           done
 
-      - name: Create release message
-        run: |
-          # Format the HISTORY of this release for the release.
-          # This file represents both the title and the body of the
-          # release.  A blank line separates the title from the body.
-
-          echo "$VERSION" >> $RELEASE_MESSAGE_FILE
-          echo "" >> $RELEASE_MESSAGE_FILE
-          echo "This bugfix release includes the following fixes and features:" >> "$RELEASE_MESSAGE_FILE"
-          echo "" >> $RELEASE_MESSAGE_FILE  # extra line to clarify we're starting a bulleted list.
-
-          # Copy the history notes for this version into the release message
-          # The tail +3 cuts off the version string and underline of the title.
-          sed -n "/$VERSION/,/^$/p" HISTORY.rst | tail -n +3 >> $RELEASE_MESSAGE_FILE
-
       - name: Create Github release
         run: |
+          # Copy the history notes for this version into the release message
+          # The tail +3 cuts off the version string and underline of the title.
           gh release create $VERSION \
-            --notes-file $RELEASE_MESSAGE_FILE \
             --verify-tag \
+            --title $VERSION \
+            --notes "
+            This release includes the following fixes and features:
+
+            $(sed -n "/$VERSION/,/^$/p" HISTORY.rst | tail -n +3)" \
             artifacts/*
 
       - name: Create a PyPI release

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,8 +35,12 @@
 
 .. :changelog:
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.13.0a4 (2023-04-07)
+---------------------
 
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and


### PR DESCRIPTION

  Release 3.13.0a4 and merge into `main`

  # 3.13.0a4 Release

  This PR contains automated changes made for the 3.13.0a4 release.

  Approving this PR will trigger an action that publishes the
  release. Declining this PR will trigger an action that rolls back
  any release steps that have completed so far.

  ## Review this PR
  - [ ] Make sure that the automated changes look correct
  - [ ] Wait for BOTH the PR checks AND the [3.13.0a4 tag checks]()        to complete. The 3.13.0a4 tag workflow is most important        because it produces the artifacts that will be used in the        next steps of the release process. If it fails for any reason,        decline this PR and start over.
  - [ ] Download and try out the artifacts from the [tag build]

  **If everything looks good**, approve and merge this PR. This will
  trigger a Github Action that will publish the release. Then go
  back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)
  and complete any remaining tasks.

  **If there is a bug**, decline this PR. Submit a fix in a separate
  PR into `main`. Once the fix has been merged, restart the release
  process from the beginning.

  **If the 3.13.0a4 tag workflow fails due to an intermittent problem**,
  decline this PR and start over.

  **If 3.13.0a4 tag workflow succeeds, but this PR workflow fails
  due to an intermittent problem**, continue with the release.
  Approve and merge this PR with a comment explaining what happened.