### PR TITLE
3.13.0a5 release

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -14,7 +14,10 @@ env:
   # this is necessary for the pr checks
   GITHUB_TOKEN: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
 
 jobs:
   finalize-and-tag:
@@ -28,7 +31,6 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "<>"
-          git remote -v
 
       # Members of the natcap software team can push to the autorelease branch on
       # natcap/invest; this branch is a special case for our release process.
@@ -65,6 +67,16 @@ jobs:
           git tag $VERSION
           git push origin $VERSION
 
+      - name: Find actions run for the $VERSION tag
+        run: |
+          # wait a few seconds to make sure the actions run exists before querying it
+          sleep 5
+          echo "TAG_RUN_URL=$( \
+            gh run list \
+              --branch $VERSION \
+              --json url \
+              --jq .[].url)" >> $GITHUB_ENV
+
       - name: Create a PR from the autorelease branch into main
         run: |
           gh pr create \
@@ -80,34 +92,30 @@ jobs:
 
             This PR contains automated changes made for the $VERSION release.
 
-            Approving this PR will trigger an action that publishes the
-            release. Declining this PR will trigger an action that rolls back
+            Approving this PR will trigger an action that publishes the \
+            release. Declining this PR will trigger an action that rolls back \
             any release steps that have completed so far.
 
             ## Review this PR
             - [ ] Make sure that the automated changes look correct
-            - [ ] Wait for BOTH the PR checks AND the [$VERSION tag checks]() \
-                 to complete. The $VERSION tag workflow is most important \
-                 because it produces the artifacts that will be used in the \
-                 next steps of the release process. If it fails for any reason, \
-                 decline this PR and start over.
-            - [ ] Download and try out the artifacts from the [tag build]
+            - [ ] Wait for BOTH the PR checks below AND the [$VERSION tag checks]($TAG_RUN_URL) \
+                  to complete. The $VERSION tag workflow is most important \
+                  because it produces the artifacts that will be used in the \
+                  next steps of the release process.
+            - [ ] Download and try out the artifacts from the [tag build]($TAG_RUN_URL)
 
-            **If everything looks good**, approve and merge this PR. This will
-            trigger a Github Action that will publish the release. Then go
-            back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)
+            **If everything looks good**, approve and merge this PR. This will \
+            trigger a Github Action that will publish the release. Then go \
+            back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist) \
             and complete any remaining tasks.
 
-            **If there is a bug**, decline this PR. Submit a fix in a separate
-            PR into \`main\`. Once the fix has been merged, restart the release
+            **If there is a bug**, decline this PR. Submit a fix in a separate \
+            PR into \`main\`. Once the fix has been merged, restart the release \
             process from the beginning.
 
-            **If the $VERSION tag workflow fails due to an intermittent problem**,
-            decline this PR and start over.
-
-            **If $VERSION tag workflow succeeds, but this PR workflow fails
-            due to an intermittent problem**, continue with the release.
-            Approve and merge this PR with a comment explaining what happened."
+            **If either workflow fails due to an intermittent problem**, \
+            rerun it through the GitHub UI. Proceed to approve and merge this \
+            PR once it succeeds."
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: conda install --channel conda-forge twine
+        run: pip install twine
 
       - name: Extract version from autorelease branch name
         run: echo "VERSION=$(echo ${{ github.head_ref }} | cut -c 13-)" >> $GITHUB_ENV
@@ -44,8 +44,7 @@ jobs:
             gh run list \
               --branch ${{ env.VERSION }} \
               --json databaseId \
-              --jq ".[].databaseId")
-          echo $RUN_ID
+              --jq .[].databaseId)
 
       - name: Download release artifacts
         run: |
@@ -58,8 +57,7 @@ jobs:
           # verify that all 6 wheels are there
           if [ `find artifacts/* | wc -l` -ne 6 ]; then exit 1; fi
 
-          # download each artifact separately so that the command will fail if
-          # any artifact is not found
+          # download each artifact separately so that the command will fail if any is missing
           for artifact in Workbench-Windows-binary \
                           Workbench-macOS-binary \
                           InVEST-sample-data \
@@ -71,6 +69,10 @@ jobs:
 
       - name: Create Github release
         run: |
+          head -n 100 HISTORY.rst
+          sed -n "/$VERSION/,/^$/p" HISTORY.rst
+          sed -n "/$VERSION/,/^$/p" HISTORY.rst | tail -n +3
+
           # Copy the history notes for this version into the release message
           # The tail +3 cuts off the version string and underline of the title.
           gh release create $VERSION \
@@ -84,7 +86,12 @@ jobs:
 
       - name: Create a PyPI release
         # this is the only step that can't be rolled back
-        run: twine upload -r testpypi artifacts/natcap.invest.*
+        run: |
+          twine upload \
+            --repository testpypi \
+            --username emlys
+            --password ${{ secrets.PYPI_PASSWORD }}
+            artifacts/natcap.invest.*
 
       - name: Roll back on failure
         if: failure()

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,8 +35,12 @@
 
 .. :changelog:
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.13.0a5 (2023-04-07)
+---------------------
 
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and


### PR DESCRIPTION

  Release 3.13.0a5 and merge into `main`

  # 3.13.0a5 Release

  This PR contains automated changes made for the 3.13.0a5 release.

  Approving this PR will trigger an action that publishes the   release. Declining this PR will trigger an action that rolls back   any release steps that have completed so far.

  ## Review this PR
  - [x] Make sure that the automated changes look correct
  - [ ] Wait for BOTH the PR checks below AND the [3.13.0a5 tag checks](https://github.com/emlys/invest-mirror/actions/runs/4642203248)         to complete. The 3.13.0a5 tag workflow is most important         because it produces the artifacts that will be used in the         next steps of the release process.
  - [ ] Download and try out the artifacts from the [tag build](https://github.com/emlys/invest-mirror/actions/runs/4642203248)

  **If everything looks good**, approve and merge this PR. This will   trigger a Github Action that will publish the release. Then go   back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)   and complete any remaining tasks.

  **If there is a bug**, decline this PR. Submit a fix in a separate   PR into `main`. Once the fix has been merged, restart the release   process from the beginning.

  **If either workflow fails due to an intermittent problem**,   rerun it through the GitHub UI. Proceed to approve and merge this   PR once it succeeds.