### PR TITLE
3.13.0a7 release

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -67,7 +67,7 @@ jobs:
           git tag $VERSION
           git push origin $VERSION
 
-      - name: Find actions run for the $VERSION tag
+      - name: Find actions run for the version tag
         run: |
           # wait a few seconds to make sure the actions run exists before querying it
           sleep 5
@@ -86,15 +86,13 @@ jobs:
             --reviewer $GITHUB_ACTOR \
             --assignee $GITHUB_ACTOR \
             --body "
-            Release $VERSION and merge into \`main\`
-
-            # $VERSION Release
+            # Release $VERSION and merge into \`main\`
 
             This PR contains automated changes made for the $VERSION release.
 
-            Approving this PR will trigger an action that publishes the \
-            release. Declining this PR will trigger an action that rolls back \
-            any release steps that have completed so far.
+            Merging this PR will trigger an action that publishes the \
+            release. Closing this PR without merging will trigger an action that \
+            rolls back any release steps that have completed so far.
 
             ## Review this PR
             - [ ] Make sure that the automated changes look correct
@@ -102,7 +100,7 @@ jobs:
                   to complete. The $VERSION tag workflow is most important \
                   because it produces the artifacts that will be used in the \
                   next steps of the release process.
-            - [ ] Download and try out the artifacts from the [tag build]($TAG_RUN_URL)
+            - [ ] Download and try out the [tag build artifacts]($TAG_RUN_URL)
 
             **If everything looks good**, approve and merge this PR. This will \
             trigger a Github Action that will publish the release. Then go \

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,8 +35,12 @@
 
 .. :changelog:
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.13.0a7 (2023-04-14)
+---------------------
 
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@
 
 Cython
 virtualenv>=12.0.1
-pytest
+pytest<7.3.0
 pytest-subtests
 wheel>=0.27.0
 pypiwin32; sys_platform == 'win32'  # pip-only


### PR DESCRIPTION

  # Release 3.13.0a7 and merge into `main`

  This PR contains automated changes made for the 3.13.0a7 release.

  Merging this PR will trigger an action that publishes the   release. Closing this PR without merging will trigger an action that   rolls back any release steps that have completed so far.

  ## Review this PR
  - [ ] Make sure that the automated changes look correct
  - [ ] Wait for BOTH the PR checks below AND the [3.13.0a7 tag checks](https://github.com/emlys/invest-mirror/actions/runs/4703099124)         to complete. The 3.13.0a7 tag workflow is most important         because it produces the artifacts that will be used in the         next steps of the release process.
  - [ ] Download and try out the [tag build artifacts](https://github.com/emlys/invest-mirror/actions/runs/4703099124)

  **If everything looks good**, approve and merge this PR. This will   trigger a Github Action that will publish the release. Then go   back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)   and complete any remaining tasks.

  **If there is a bug**, decline this PR. Submit a fix in a separate   PR into `main`. Once the fix has been merged, restart the release   process from the beginning.

  **If either workflow fails due to an intermittent problem**,   rerun it through the GitHub UI. Proceed to approve and merge this   PR once it succeeds.