### PR TITLE
3.13.0a8 release

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -98,4 +98,4 @@ jobs:
         uses: ./.github/actions/rollback_release
         with:
           VERSION: ${{ env.VERSION }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -69,19 +69,16 @@ jobs:
 
       - name: Create Github release
         run: |
-          head -n 100 HISTORY.rst
-          sed -n "/$VERSION/,/^$/p" HISTORY.rst
-          sed -n "/$VERSION/,/^$/p" HISTORY.rst | tail -n +3
-
           # Copy the history notes for this version into the release message
-          # The tail +3 cuts off the version string and underline of the title.
+          # The sed | tail | sed | head command extracts everything in the
+          # first section of the RST file (between ---- section dividers)
           gh release create $VERSION \
             --verify-tag \
             --title $VERSION \
             --notes "
             This release includes the following fixes and features:
 
-            $(sed -n "/$VERSION/,/^$/p" HISTORY.rst | tail -n +3)" \
+            $(sed -n '/^---*/,$ p' HISTORY.rst | tail -n +2 | sed '/^---*/q' | head -n -2)" \
             artifacts/*
 
       - name: Create a PyPI release

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,8 +35,12 @@
 
 .. :changelog:
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.13.0a8 (2023-04-17)
+---------------------
 
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and


### PR DESCRIPTION

  # Release 3.13.0a8 and merge into `main`

  This PR contains automated changes made for the 3.13.0a8 release.

  Merging this PR will trigger an action that publishes the   release. Closing this PR without merging will trigger an action that   rolls back any release steps that have completed so far.

  ## Review this PR
  - [ ] Make sure that the automated changes look correct
  - [ ] Wait for BOTH the PR checks below AND the [3.13.0a8 tag checks](https://github.com/emlys/invest-mirror/actions/runs/4725594840)         to complete. The 3.13.0a8 tag workflow is most important         because it produces the artifacts that will be used in the         next steps of the release process.
  - [ ] Download and try out the [tag build artifacts](https://github.com/emlys/invest-mirror/actions/runs/4725594840)

  **If everything looks good**, approve and merge this PR. This will   trigger a Github Action that will publish the release. Then go   back to the [Release Checklist](https://github.com/natcap/invest/wiki/Release-Checklist)   and complete any remaining tasks.

  **If there is a bug**, decline this PR. Submit a fix in a separate   PR into `main`. Once the fix has been merged, restart the release   process from the beginning.

  **If either workflow fails due to an intermittent problem**,   rerun it through the GitHub UI. Proceed to approve and merge this   PR once it succeeds.